### PR TITLE
feat(forms): Allow focus on attach

### DIFF
--- a/dist/amd/components/form/form-text.d.ts
+++ b/dist/amd/components/form/form-text.d.ts
@@ -1,4 +1,6 @@
+import { TaskQueue } from 'aurelia-framework';
 export declare class ReFormText {
+    private taskQueue;
     label: string;
     name: string;
     placeholder: string;
@@ -15,8 +17,11 @@ export declare class ReFormText {
     patternError: string;
     validated: null | boolean;
     validateOnKeyup: null | boolean;
+    focusOnAttach: null | boolean;
+    private inputElement;
     private _regex;
     private errorMessage;
+    constructor(taskQueue: TaskQueue);
     typeChanged(n: string): void;
     patternChanged(): void;
     attached(): void;

--- a/dist/amd/components/form/form-text.html
+++ b/dist/amd/components/form/form-text.html
@@ -2,6 +2,7 @@
   <div class="form ${inline ? 'form--inline' : ''}" re-error-class.bind="isError" re-success-class.bind="isSuccess" data-error="form" data-success="form">
     <div class="form__input">
       <input
+        ref="inputElement"
         type="${type}"
         name="${name}"
         placeholder="${placeholder}"

--- a/dist/amd/components/form/form-text.js
+++ b/dist/amd/components/form/form-text.js
@@ -41,7 +41,6 @@ define(["require", "exports", "aurelia-templating", "aurelia-binding", "aurelia-
             var _this = this;
             if (this.focusOnAttach) {
                 this.taskQueue.queueMicroTask(function () {
-                    console.log('here');
                     if (_this.inputElement !== null) {
                         _this.inputElement.focus();
                     }

--- a/dist/amd/components/form/form-text.js
+++ b/dist/amd/components/form/form-text.js
@@ -4,11 +4,12 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
-define(["require", "exports", "aurelia-templating", "aurelia-binding"], function (require, exports, aurelia_templating_1, aurelia_binding_1) {
+define(["require", "exports", "aurelia-templating", "aurelia-binding", "aurelia-framework"], function (require, exports, aurelia_templating_1, aurelia_binding_1, aurelia_framework_1) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var ReFormText = /** @class */ (function () {
-        function ReFormText() {
+        function ReFormText(taskQueue) {
+            this.taskQueue = taskQueue;
             this.label = '';
             this.name = '';
             this.placeholder = '';
@@ -25,6 +26,8 @@ define(["require", "exports", "aurelia-templating", "aurelia-binding"], function
             this.patternError = '';
             this.validated = null;
             this.validateOnKeyup = null;
+            this.focusOnAttach = null;
+            this.inputElement = null;
             this._regex = /./;
             this.errorMessage = '';
         }
@@ -35,6 +38,15 @@ define(["require", "exports", "aurelia-templating", "aurelia-binding"], function
             this._resetRegex();
         };
         ReFormText.prototype.attached = function () {
+            var _this = this;
+            if (this.focusOnAttach) {
+                this.taskQueue.queueMicroTask(function () {
+                    console.log('here');
+                    if (_this.inputElement !== null) {
+                        _this.inputElement.focus();
+                    }
+                });
+            }
             this._validate();
         };
         ReFormText.prototype._resetRegex = function (newType) {
@@ -177,8 +189,14 @@ define(["require", "exports", "aurelia-templating", "aurelia-binding"], function
                 defaultBindingMode: aurelia_binding_1.bindingMode.oneWay
             })
         ], ReFormText.prototype, "validateOnKeyup", void 0);
+        __decorate([
+            aurelia_templating_1.bindable({
+                defaulltBindingMode: aurelia_binding_1.bindingMode.oneTime
+            })
+        ], ReFormText.prototype, "focusOnAttach", void 0);
         ReFormText = __decorate([
-            aurelia_templating_1.customElement('re-form-text')
+            aurelia_templating_1.customElement('re-form-text'),
+            aurelia_framework_1.inject(aurelia_framework_1.TaskQueue)
         ], ReFormText);
         return ReFormText;
     }());

--- a/dist/amd/components/form/form-textarea.d.ts
+++ b/dist/amd/components/form/form-textarea.d.ts
@@ -1,4 +1,6 @@
+import { TaskQueue } from 'aurelia-framework';
 export declare class ReFormTextarea {
+    private taskQueue;
     label: string;
     name: string;
     placeholder: string;
@@ -8,4 +10,8 @@ export declare class ReFormTextarea {
     hint: string;
     value: string;
     rows: string;
+    focusOnAttach: null | boolean;
+    private inputElement;
+    constructor(taskQueue: TaskQueue);
+    attached(): void;
 }

--- a/dist/amd/components/form/form-textarea.js
+++ b/dist/amd/components/form/form-textarea.js
@@ -4,11 +4,12 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
-define(["require", "exports", "aurelia-templating", "aurelia-binding"], function (require, exports, aurelia_templating_1, aurelia_binding_1) {
+define(["require", "exports", "aurelia-templating", "aurelia-binding", "aurelia-framework"], function (require, exports, aurelia_templating_1, aurelia_binding_1, aurelia_framework_1) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var ReFormTextarea = /** @class */ (function () {
-        function ReFormTextarea() {
+        function ReFormTextarea(taskQueue) {
+            this.taskQueue = taskQueue;
             this.label = '';
             this.name = '';
             this.placeholder = '';
@@ -18,7 +19,19 @@ define(["require", "exports", "aurelia-templating", "aurelia-binding"], function
             this.hint = '';
             this.value = '';
             this.rows = '';
+            this.focusOnAttach = null;
+            this.inputElement = null;
         }
+        ReFormTextarea.prototype.attached = function () {
+            var _this = this;
+            if (this.focusOnAttach) {
+                this.taskQueue.queueMicroTask(function () {
+                    if (_this.inputElement !== null) {
+                        _this.inputElement.focus();
+                    }
+                });
+            }
+        };
         __decorate([
             aurelia_templating_1.bindable({
                 defaultBindingMode: aurelia_binding_1.bindingMode.oneTime
@@ -62,8 +75,14 @@ define(["require", "exports", "aurelia-templating", "aurelia-binding"], function
         __decorate([
             aurelia_templating_1.bindable()
         ], ReFormTextarea.prototype, "rows", void 0);
+        __decorate([
+            aurelia_templating_1.bindable({
+                defaulltBindingMode: aurelia_binding_1.bindingMode.oneTime
+            })
+        ], ReFormTextarea.prototype, "focusOnAttach", void 0);
         ReFormTextarea = __decorate([
-            aurelia_templating_1.customElement('re-form-textarea')
+            aurelia_templating_1.customElement('re-form-textarea'),
+            aurelia_framework_1.inject(aurelia_framework_1.TaskQueue)
         ], ReFormTextarea);
         return ReFormTextarea;
     }());

--- a/dist/commonjs/components/form/form-text.d.ts
+++ b/dist/commonjs/components/form/form-text.d.ts
@@ -1,4 +1,6 @@
+import { TaskQueue } from 'aurelia-framework';
 export declare class ReFormText {
+    private taskQueue;
     label: string;
     name: string;
     placeholder: string;
@@ -15,8 +17,11 @@ export declare class ReFormText {
     patternError: string;
     validated: null | boolean;
     validateOnKeyup: null | boolean;
+    focusOnAttach: null | boolean;
+    private inputElement;
     private _regex;
     private errorMessage;
+    constructor(taskQueue: TaskQueue);
     typeChanged(n: string): void;
     patternChanged(): void;
     attached(): void;

--- a/dist/commonjs/components/form/form-text.html
+++ b/dist/commonjs/components/form/form-text.html
@@ -2,6 +2,7 @@
   <div class="form ${inline ? 'form--inline' : ''}" re-error-class.bind="isError" re-success-class.bind="isSuccess" data-error="form" data-success="form">
     <div class="form__input">
       <input
+        ref="inputElement"
         type="${type}"
         name="${name}"
         placeholder="${placeholder}"

--- a/dist/commonjs/components/form/form-text.js
+++ b/dist/commonjs/components/form/form-text.js
@@ -43,7 +43,6 @@ var ReFormText = /** @class */ (function () {
         var _this = this;
         if (this.focusOnAttach) {
             this.taskQueue.queueMicroTask(function () {
-                console.log('here');
                 if (_this.inputElement !== null) {
                     _this.inputElement.focus();
                 }

--- a/dist/commonjs/components/form/form-text.js
+++ b/dist/commonjs/components/form/form-text.js
@@ -8,8 +8,10 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
 Object.defineProperty(exports, "__esModule", { value: true });
 var aurelia_templating_1 = require("aurelia-templating");
 var aurelia_binding_1 = require("aurelia-binding");
+var aurelia_framework_1 = require("aurelia-framework");
 var ReFormText = /** @class */ (function () {
-    function ReFormText() {
+    function ReFormText(taskQueue) {
+        this.taskQueue = taskQueue;
         this.label = '';
         this.name = '';
         this.placeholder = '';
@@ -26,6 +28,8 @@ var ReFormText = /** @class */ (function () {
         this.patternError = '';
         this.validated = null;
         this.validateOnKeyup = null;
+        this.focusOnAttach = null;
+        this.inputElement = null;
         this._regex = /./;
         this.errorMessage = '';
     }
@@ -36,6 +40,15 @@ var ReFormText = /** @class */ (function () {
         this._resetRegex();
     };
     ReFormText.prototype.attached = function () {
+        var _this = this;
+        if (this.focusOnAttach) {
+            this.taskQueue.queueMicroTask(function () {
+                console.log('here');
+                if (_this.inputElement !== null) {
+                    _this.inputElement.focus();
+                }
+            });
+        }
         this._validate();
     };
     ReFormText.prototype._resetRegex = function (newType) {
@@ -178,8 +191,14 @@ var ReFormText = /** @class */ (function () {
             defaultBindingMode: aurelia_binding_1.bindingMode.oneWay
         })
     ], ReFormText.prototype, "validateOnKeyup", void 0);
+    __decorate([
+        aurelia_templating_1.bindable({
+            defaulltBindingMode: aurelia_binding_1.bindingMode.oneTime
+        })
+    ], ReFormText.prototype, "focusOnAttach", void 0);
     ReFormText = __decorate([
-        aurelia_templating_1.customElement('re-form-text')
+        aurelia_templating_1.customElement('re-form-text'),
+        aurelia_framework_1.inject(aurelia_framework_1.TaskQueue)
     ], ReFormText);
     return ReFormText;
 }());

--- a/dist/commonjs/components/form/form-textarea.d.ts
+++ b/dist/commonjs/components/form/form-textarea.d.ts
@@ -1,4 +1,6 @@
+import { TaskQueue } from 'aurelia-framework';
 export declare class ReFormTextarea {
+    private taskQueue;
     label: string;
     name: string;
     placeholder: string;
@@ -8,4 +10,8 @@ export declare class ReFormTextarea {
     hint: string;
     value: string;
     rows: string;
+    focusOnAttach: null | boolean;
+    private inputElement;
+    constructor(taskQueue: TaskQueue);
+    attached(): void;
 }

--- a/dist/commonjs/components/form/form-textarea.js
+++ b/dist/commonjs/components/form/form-textarea.js
@@ -8,8 +8,10 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
 Object.defineProperty(exports, "__esModule", { value: true });
 var aurelia_templating_1 = require("aurelia-templating");
 var aurelia_binding_1 = require("aurelia-binding");
+var aurelia_framework_1 = require("aurelia-framework");
 var ReFormTextarea = /** @class */ (function () {
-    function ReFormTextarea() {
+    function ReFormTextarea(taskQueue) {
+        this.taskQueue = taskQueue;
         this.label = '';
         this.name = '';
         this.placeholder = '';
@@ -19,7 +21,19 @@ var ReFormTextarea = /** @class */ (function () {
         this.hint = '';
         this.value = '';
         this.rows = '';
+        this.focusOnAttach = null;
+        this.inputElement = null;
     }
+    ReFormTextarea.prototype.attached = function () {
+        var _this = this;
+        if (this.focusOnAttach) {
+            this.taskQueue.queueMicroTask(function () {
+                if (_this.inputElement !== null) {
+                    _this.inputElement.focus();
+                }
+            });
+        }
+    };
     __decorate([
         aurelia_templating_1.bindable({
             defaultBindingMode: aurelia_binding_1.bindingMode.oneTime
@@ -63,8 +77,14 @@ var ReFormTextarea = /** @class */ (function () {
     __decorate([
         aurelia_templating_1.bindable()
     ], ReFormTextarea.prototype, "rows", void 0);
+    __decorate([
+        aurelia_templating_1.bindable({
+            defaulltBindingMode: aurelia_binding_1.bindingMode.oneTime
+        })
+    ], ReFormTextarea.prototype, "focusOnAttach", void 0);
     ReFormTextarea = __decorate([
-        aurelia_templating_1.customElement('re-form-textarea')
+        aurelia_templating_1.customElement('re-form-textarea'),
+        aurelia_framework_1.inject(aurelia_framework_1.TaskQueue)
     ], ReFormTextarea);
     return ReFormTextarea;
 }());

--- a/dist/es2015/components/form/form-text.d.ts
+++ b/dist/es2015/components/form/form-text.d.ts
@@ -1,4 +1,6 @@
+import { TaskQueue } from 'aurelia-framework';
 export declare class ReFormText {
+    private taskQueue;
     label: string;
     name: string;
     placeholder: string;
@@ -15,8 +17,11 @@ export declare class ReFormText {
     patternError: string;
     validated: null | boolean;
     validateOnKeyup: null | boolean;
+    focusOnAttach: null | boolean;
+    private inputElement;
     private _regex;
     private errorMessage;
+    constructor(taskQueue: TaskQueue);
     typeChanged(n: string): void;
     patternChanged(): void;
     attached(): void;

--- a/dist/es2015/components/form/form-text.html
+++ b/dist/es2015/components/form/form-text.html
@@ -2,6 +2,7 @@
   <div class="form ${inline ? 'form--inline' : ''}" re-error-class.bind="isError" re-success-class.bind="isSuccess" data-error="form" data-success="form">
     <div class="form__input">
       <input
+        ref="inputElement"
         type="${type}"
         name="${name}"
         placeholder="${placeholder}"

--- a/dist/es2015/components/form/form-text.js
+++ b/dist/es2015/components/form/form-text.js
@@ -6,8 +6,10 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
 };
 import { bindable, customElement } from 'aurelia-templating';
 import { bindingMode } from 'aurelia-binding';
+import { inject, TaskQueue } from 'aurelia-framework';
 var ReFormText = /** @class */ (function () {
-    function ReFormText() {
+    function ReFormText(taskQueue) {
+        this.taskQueue = taskQueue;
         this.label = '';
         this.name = '';
         this.placeholder = '';
@@ -24,6 +26,8 @@ var ReFormText = /** @class */ (function () {
         this.patternError = '';
         this.validated = null;
         this.validateOnKeyup = null;
+        this.focusOnAttach = null;
+        this.inputElement = null;
         this._regex = /./;
         this.errorMessage = '';
     }
@@ -34,6 +38,15 @@ var ReFormText = /** @class */ (function () {
         this._resetRegex();
     };
     ReFormText.prototype.attached = function () {
+        var _this = this;
+        if (this.focusOnAttach) {
+            this.taskQueue.queueMicroTask(function () {
+                console.log('here');
+                if (_this.inputElement !== null) {
+                    _this.inputElement.focus();
+                }
+            });
+        }
         this._validate();
     };
     ReFormText.prototype._resetRegex = function (newType) {
@@ -176,8 +189,14 @@ var ReFormText = /** @class */ (function () {
             defaultBindingMode: bindingMode.oneWay
         })
     ], ReFormText.prototype, "validateOnKeyup", void 0);
+    __decorate([
+        bindable({
+            defaulltBindingMode: bindingMode.oneTime
+        })
+    ], ReFormText.prototype, "focusOnAttach", void 0);
     ReFormText = __decorate([
-        customElement('re-form-text')
+        customElement('re-form-text'),
+        inject(TaskQueue)
     ], ReFormText);
     return ReFormText;
 }());

--- a/dist/es2015/components/form/form-text.js
+++ b/dist/es2015/components/form/form-text.js
@@ -41,7 +41,6 @@ var ReFormText = /** @class */ (function () {
         var _this = this;
         if (this.focusOnAttach) {
             this.taskQueue.queueMicroTask(function () {
-                console.log('here');
                 if (_this.inputElement !== null) {
                     _this.inputElement.focus();
                 }

--- a/dist/es2015/components/form/form-textarea.d.ts
+++ b/dist/es2015/components/form/form-textarea.d.ts
@@ -1,4 +1,6 @@
+import { TaskQueue } from 'aurelia-framework';
 export declare class ReFormTextarea {
+    private taskQueue;
     label: string;
     name: string;
     placeholder: string;
@@ -8,4 +10,8 @@ export declare class ReFormTextarea {
     hint: string;
     value: string;
     rows: string;
+    focusOnAttach: null | boolean;
+    private inputElement;
+    constructor(taskQueue: TaskQueue);
+    attached(): void;
 }

--- a/dist/es2015/components/form/form-textarea.js
+++ b/dist/es2015/components/form/form-textarea.js
@@ -6,8 +6,10 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
 };
 import { bindable, customElement } from 'aurelia-templating';
 import { bindingMode } from 'aurelia-binding';
+import { TaskQueue, inject } from 'aurelia-framework';
 var ReFormTextarea = /** @class */ (function () {
-    function ReFormTextarea() {
+    function ReFormTextarea(taskQueue) {
+        this.taskQueue = taskQueue;
         this.label = '';
         this.name = '';
         this.placeholder = '';
@@ -17,7 +19,19 @@ var ReFormTextarea = /** @class */ (function () {
         this.hint = '';
         this.value = '';
         this.rows = '';
+        this.focusOnAttach = null;
+        this.inputElement = null;
     }
+    ReFormTextarea.prototype.attached = function () {
+        var _this = this;
+        if (this.focusOnAttach) {
+            this.taskQueue.queueMicroTask(function () {
+                if (_this.inputElement !== null) {
+                    _this.inputElement.focus();
+                }
+            });
+        }
+    };
     __decorate([
         bindable({
             defaultBindingMode: bindingMode.oneTime
@@ -61,8 +75,14 @@ var ReFormTextarea = /** @class */ (function () {
     __decorate([
         bindable()
     ], ReFormTextarea.prototype, "rows", void 0);
+    __decorate([
+        bindable({
+            defaulltBindingMode: bindingMode.oneTime
+        })
+    ], ReFormTextarea.prototype, "focusOnAttach", void 0);
     ReFormTextarea = __decorate([
-        customElement('re-form-textarea')
+        customElement('re-form-textarea'),
+        inject(TaskQueue)
     ], ReFormTextarea);
     return ReFormTextarea;
 }());

--- a/dist/native-modules/components/form/form-text.d.ts
+++ b/dist/native-modules/components/form/form-text.d.ts
@@ -1,4 +1,6 @@
+import { TaskQueue } from 'aurelia-framework';
 export declare class ReFormText {
+    private taskQueue;
     label: string;
     name: string;
     placeholder: string;
@@ -15,8 +17,11 @@ export declare class ReFormText {
     patternError: string;
     validated: null | boolean;
     validateOnKeyup: null | boolean;
+    focusOnAttach: null | boolean;
+    private inputElement;
     private _regex;
     private errorMessage;
+    constructor(taskQueue: TaskQueue);
     typeChanged(n: string): void;
     patternChanged(): void;
     attached(): void;

--- a/dist/native-modules/components/form/form-text.html
+++ b/dist/native-modules/components/form/form-text.html
@@ -2,6 +2,7 @@
   <div class="form ${inline ? 'form--inline' : ''}" re-error-class.bind="isError" re-success-class.bind="isSuccess" data-error="form" data-success="form">
     <div class="form__input">
       <input
+        ref="inputElement"
         type="${type}"
         name="${name}"
         placeholder="${placeholder}"

--- a/dist/native-modules/components/form/form-text.js
+++ b/dist/native-modules/components/form/form-text.js
@@ -6,8 +6,10 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
 };
 import { bindable, customElement } from 'aurelia-templating';
 import { bindingMode } from 'aurelia-binding';
+import { inject, TaskQueue } from 'aurelia-framework';
 var ReFormText = /** @class */ (function () {
-    function ReFormText() {
+    function ReFormText(taskQueue) {
+        this.taskQueue = taskQueue;
         this.label = '';
         this.name = '';
         this.placeholder = '';
@@ -24,6 +26,8 @@ var ReFormText = /** @class */ (function () {
         this.patternError = '';
         this.validated = null;
         this.validateOnKeyup = null;
+        this.focusOnAttach = null;
+        this.inputElement = null;
         this._regex = /./;
         this.errorMessage = '';
     }
@@ -34,6 +38,15 @@ var ReFormText = /** @class */ (function () {
         this._resetRegex();
     };
     ReFormText.prototype.attached = function () {
+        var _this = this;
+        if (this.focusOnAttach) {
+            this.taskQueue.queueMicroTask(function () {
+                console.log('here');
+                if (_this.inputElement !== null) {
+                    _this.inputElement.focus();
+                }
+            });
+        }
         this._validate();
     };
     ReFormText.prototype._resetRegex = function (newType) {
@@ -176,8 +189,14 @@ var ReFormText = /** @class */ (function () {
             defaultBindingMode: bindingMode.oneWay
         })
     ], ReFormText.prototype, "validateOnKeyup", void 0);
+    __decorate([
+        bindable({
+            defaulltBindingMode: bindingMode.oneTime
+        })
+    ], ReFormText.prototype, "focusOnAttach", void 0);
     ReFormText = __decorate([
-        customElement('re-form-text')
+        customElement('re-form-text'),
+        inject(TaskQueue)
     ], ReFormText);
     return ReFormText;
 }());

--- a/dist/native-modules/components/form/form-text.js
+++ b/dist/native-modules/components/form/form-text.js
@@ -41,7 +41,6 @@ var ReFormText = /** @class */ (function () {
         var _this = this;
         if (this.focusOnAttach) {
             this.taskQueue.queueMicroTask(function () {
-                console.log('here');
                 if (_this.inputElement !== null) {
                     _this.inputElement.focus();
                 }

--- a/dist/native-modules/components/form/form-textarea.d.ts
+++ b/dist/native-modules/components/form/form-textarea.d.ts
@@ -1,4 +1,6 @@
+import { TaskQueue } from 'aurelia-framework';
 export declare class ReFormTextarea {
+    private taskQueue;
     label: string;
     name: string;
     placeholder: string;
@@ -8,4 +10,8 @@ export declare class ReFormTextarea {
     hint: string;
     value: string;
     rows: string;
+    focusOnAttach: null | boolean;
+    private inputElement;
+    constructor(taskQueue: TaskQueue);
+    attached(): void;
 }

--- a/dist/native-modules/components/form/form-textarea.js
+++ b/dist/native-modules/components/form/form-textarea.js
@@ -6,8 +6,10 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
 };
 import { bindable, customElement } from 'aurelia-templating';
 import { bindingMode } from 'aurelia-binding';
+import { TaskQueue, inject } from 'aurelia-framework';
 var ReFormTextarea = /** @class */ (function () {
-    function ReFormTextarea() {
+    function ReFormTextarea(taskQueue) {
+        this.taskQueue = taskQueue;
         this.label = '';
         this.name = '';
         this.placeholder = '';
@@ -17,7 +19,19 @@ var ReFormTextarea = /** @class */ (function () {
         this.hint = '';
         this.value = '';
         this.rows = '';
+        this.focusOnAttach = null;
+        this.inputElement = null;
     }
+    ReFormTextarea.prototype.attached = function () {
+        var _this = this;
+        if (this.focusOnAttach) {
+            this.taskQueue.queueMicroTask(function () {
+                if (_this.inputElement !== null) {
+                    _this.inputElement.focus();
+                }
+            });
+        }
+    };
     __decorate([
         bindable({
             defaultBindingMode: bindingMode.oneTime
@@ -61,8 +75,14 @@ var ReFormTextarea = /** @class */ (function () {
     __decorate([
         bindable()
     ], ReFormTextarea.prototype, "rows", void 0);
+    __decorate([
+        bindable({
+            defaulltBindingMode: bindingMode.oneTime
+        })
+    ], ReFormTextarea.prototype, "focusOnAttach", void 0);
     ReFormTextarea = __decorate([
-        customElement('re-form-textarea')
+        customElement('re-form-textarea'),
+        inject(TaskQueue)
     ], ReFormTextarea);
     return ReFormTextarea;
 }());

--- a/dist/system/components/form/form-text.d.ts
+++ b/dist/system/components/form/form-text.d.ts
@@ -1,4 +1,6 @@
+import { TaskQueue } from 'aurelia-framework';
 export declare class ReFormText {
+    private taskQueue;
     label: string;
     name: string;
     placeholder: string;
@@ -15,8 +17,11 @@ export declare class ReFormText {
     patternError: string;
     validated: null | boolean;
     validateOnKeyup: null | boolean;
+    focusOnAttach: null | boolean;
+    private inputElement;
     private _regex;
     private errorMessage;
+    constructor(taskQueue: TaskQueue);
     typeChanged(n: string): void;
     patternChanged(): void;
     attached(): void;

--- a/dist/system/components/form/form-text.html
+++ b/dist/system/components/form/form-text.html
@@ -2,6 +2,7 @@
   <div class="form ${inline ? 'form--inline' : ''}" re-error-class.bind="isError" re-success-class.bind="isSuccess" data-error="form" data-success="form">
     <div class="form__input">
       <input
+        ref="inputElement"
         type="${type}"
         name="${name}"
         placeholder="${placeholder}"

--- a/dist/system/components/form/form-text.js
+++ b/dist/system/components/form/form-text.js
@@ -55,7 +55,6 @@ System.register(["aurelia-templating", "aurelia-binding", "aurelia-framework"], 
                     var _this = this;
                     if (this.focusOnAttach) {
                         this.taskQueue.queueMicroTask(function () {
-                            console.log('here');
                             if (_this.inputElement !== null) {
                                 _this.inputElement.focus();
                             }

--- a/dist/system/components/form/form-text.js
+++ b/dist/system/components/form/form-text.js
@@ -1,4 +1,4 @@
-System.register(["aurelia-templating", "aurelia-binding"], function (exports_1, context_1) {
+System.register(["aurelia-templating", "aurelia-binding", "aurelia-framework"], function (exports_1, context_1) {
     "use strict";
     var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
         var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -6,7 +6,7 @@ System.register(["aurelia-templating", "aurelia-binding"], function (exports_1, 
         else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
         return c > 3 && r && Object.defineProperty(target, key, r), r;
     };
-    var aurelia_templating_1, aurelia_binding_1, ReFormText;
+    var aurelia_templating_1, aurelia_binding_1, aurelia_framework_1, ReFormText;
     var __moduleName = context_1 && context_1.id;
     return {
         setters: [
@@ -15,11 +15,15 @@ System.register(["aurelia-templating", "aurelia-binding"], function (exports_1, 
             },
             function (aurelia_binding_1_1) {
                 aurelia_binding_1 = aurelia_binding_1_1;
+            },
+            function (aurelia_framework_1_1) {
+                aurelia_framework_1 = aurelia_framework_1_1;
             }
         ],
         execute: function () {
             ReFormText = /** @class */ (function () {
-                function ReFormText() {
+                function ReFormText(taskQueue) {
+                    this.taskQueue = taskQueue;
                     this.label = '';
                     this.name = '';
                     this.placeholder = '';
@@ -36,6 +40,8 @@ System.register(["aurelia-templating", "aurelia-binding"], function (exports_1, 
                     this.patternError = '';
                     this.validated = null;
                     this.validateOnKeyup = null;
+                    this.focusOnAttach = null;
+                    this.inputElement = null;
                     this._regex = /./;
                     this.errorMessage = '';
                 }
@@ -46,6 +52,15 @@ System.register(["aurelia-templating", "aurelia-binding"], function (exports_1, 
                     this._resetRegex();
                 };
                 ReFormText.prototype.attached = function () {
+                    var _this = this;
+                    if (this.focusOnAttach) {
+                        this.taskQueue.queueMicroTask(function () {
+                            console.log('here');
+                            if (_this.inputElement !== null) {
+                                _this.inputElement.focus();
+                            }
+                        });
+                    }
                     this._validate();
                 };
                 ReFormText.prototype._resetRegex = function (newType) {
@@ -188,8 +203,14 @@ System.register(["aurelia-templating", "aurelia-binding"], function (exports_1, 
                         defaultBindingMode: aurelia_binding_1.bindingMode.oneWay
                     })
                 ], ReFormText.prototype, "validateOnKeyup", void 0);
+                __decorate([
+                    aurelia_templating_1.bindable({
+                        defaulltBindingMode: aurelia_binding_1.bindingMode.oneTime
+                    })
+                ], ReFormText.prototype, "focusOnAttach", void 0);
                 ReFormText = __decorate([
-                    aurelia_templating_1.customElement('re-form-text')
+                    aurelia_templating_1.customElement('re-form-text'),
+                    aurelia_framework_1.inject(aurelia_framework_1.TaskQueue)
                 ], ReFormText);
                 return ReFormText;
             }());

--- a/dist/system/components/form/form-textarea.d.ts
+++ b/dist/system/components/form/form-textarea.d.ts
@@ -1,4 +1,6 @@
+import { TaskQueue } from 'aurelia-framework';
 export declare class ReFormTextarea {
+    private taskQueue;
     label: string;
     name: string;
     placeholder: string;
@@ -8,4 +10,8 @@ export declare class ReFormTextarea {
     hint: string;
     value: string;
     rows: string;
+    focusOnAttach: null | boolean;
+    private inputElement;
+    constructor(taskQueue: TaskQueue);
+    attached(): void;
 }

--- a/dist/system/components/form/form-textarea.js
+++ b/dist/system/components/form/form-textarea.js
@@ -1,4 +1,4 @@
-System.register(["aurelia-templating", "aurelia-binding"], function (exports_1, context_1) {
+System.register(["aurelia-templating", "aurelia-binding", "aurelia-framework"], function (exports_1, context_1) {
     "use strict";
     var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
         var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -6,7 +6,7 @@ System.register(["aurelia-templating", "aurelia-binding"], function (exports_1, 
         else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
         return c > 3 && r && Object.defineProperty(target, key, r), r;
     };
-    var aurelia_templating_1, aurelia_binding_1, ReFormTextarea;
+    var aurelia_templating_1, aurelia_binding_1, aurelia_framework_1, ReFormTextarea;
     var __moduleName = context_1 && context_1.id;
     return {
         setters: [
@@ -15,11 +15,15 @@ System.register(["aurelia-templating", "aurelia-binding"], function (exports_1, 
             },
             function (aurelia_binding_1_1) {
                 aurelia_binding_1 = aurelia_binding_1_1;
+            },
+            function (aurelia_framework_1_1) {
+                aurelia_framework_1 = aurelia_framework_1_1;
             }
         ],
         execute: function () {
             ReFormTextarea = /** @class */ (function () {
-                function ReFormTextarea() {
+                function ReFormTextarea(taskQueue) {
+                    this.taskQueue = taskQueue;
                     this.label = '';
                     this.name = '';
                     this.placeholder = '';
@@ -29,7 +33,19 @@ System.register(["aurelia-templating", "aurelia-binding"], function (exports_1, 
                     this.hint = '';
                     this.value = '';
                     this.rows = '';
+                    this.focusOnAttach = null;
+                    this.inputElement = null;
                 }
+                ReFormTextarea.prototype.attached = function () {
+                    var _this = this;
+                    if (this.focusOnAttach) {
+                        this.taskQueue.queueMicroTask(function () {
+                            if (_this.inputElement !== null) {
+                                _this.inputElement.focus();
+                            }
+                        });
+                    }
+                };
                 __decorate([
                     aurelia_templating_1.bindable({
                         defaultBindingMode: aurelia_binding_1.bindingMode.oneTime
@@ -73,8 +89,14 @@ System.register(["aurelia-templating", "aurelia-binding"], function (exports_1, 
                 __decorate([
                     aurelia_templating_1.bindable()
                 ], ReFormTextarea.prototype, "rows", void 0);
+                __decorate([
+                    aurelia_templating_1.bindable({
+                        defaulltBindingMode: aurelia_binding_1.bindingMode.oneTime
+                    })
+                ], ReFormTextarea.prototype, "focusOnAttach", void 0);
                 ReFormTextarea = __decorate([
-                    aurelia_templating_1.customElement('re-form-textarea')
+                    aurelia_templating_1.customElement('re-form-textarea'),
+                    aurelia_framework_1.inject(aurelia_framework_1.TaskQueue)
                 ], ReFormTextarea);
                 return ReFormTextarea;
             }());

--- a/src/components/form/form-text.html
+++ b/src/components/form/form-text.html
@@ -2,6 +2,7 @@
   <div class="form ${inline ? 'form--inline' : ''}" re-error-class.bind="isError" re-success-class.bind="isSuccess" data-error="form" data-success="form">
     <div class="form__input">
       <input
+        ref="inputElement"
         type="${type}"
         name="${name}"
         placeholder="${placeholder}"

--- a/src/components/form/form-text.md
+++ b/src/components/form/form-text.md
@@ -4,24 +4,25 @@ This is the form text component, which is probably one of the most used form com
 
 Here are the attributes that you can assign:
 
-| attributes        | type    | default | description                                       |
-|-------------------|---------|---------|---------------------------------------------------|
-| label             | string  | null    | Label for the form                                |
-| name              | string  | null    | Name for the form                                 |
-| placeholder       | string  | null    | Placeholder for the form                          |
-| disabled          | boolean | false   | HTML5 disabled                                    |
-| readonly          | boolean | false   | HTML5 readonly                                    |
-| inline            | boolean | false   | Set form to be inline or not                      |
-| hint              | string  | null    | Hit for the form                                  |
-| action-href       | string  | null    | The link for the action to go to                  |
-| action-label      | string  | null    | The label for the action                          |
-| value             | string  | null    | The value of the text                             |
-| maxlength         | int     | null    | HTML5 maxlength                                   |
-| type              | string  | text    | HTML5 type, also used for some default validation | 
-| pattern           | RegExp  | null    | Regex pattern to validate against                 |
-| pattern-error     | string  | null    | Error to display if pattern does not match        |
-| validated         | boolean | null    | Whether or not it is validated                    |
-| validate-on-keyup | boolean | null    | Whether or not to validate on keyup event         |
+| attributes        | type    | default | description                                               |
+|-------------------|---------|---------|-----------------------------------------------------------|
+| label             | string  | null    | Label for the form                                        |
+| name              | string  | null    | Name for the form                                         |
+| placeholder       | string  | null    | Placeholder for the form                                  |
+| disabled          | boolean | false   | HTML5 disabled                                            |
+| readonly          | boolean | false   | HTML5 readonly                                            |
+| inline            | boolean | false   | Set form to be inline or not                              |
+| hint              | string  | null    | Hit for the form                                          |
+| action-href       | string  | null    | The link for the action to go to                          |
+| action-label      | string  | null    | The label for the action                                  |
+| value             | string  | null    | The value of the text                                     |
+| maxlength         | int     | null    | HTML5 maxlength                                           |
+| type              | string  | text    | HTML5 type, also used for some default validation         | 
+| pattern           | RegExp  | null    | Regex pattern to validate against                         |
+| pattern-error     | string  | null    | Error to display if pattern does not match                |
+| validated         | boolean | null    | Whether or not it is validated                            |
+| validate-on-keyup | boolean | null    | Whether or not to validate on keyup event                 |
+| focus-on-attach   | boolean | null    | Whether or not to focus the element when it gets attached |
 
 
 ### Types

--- a/src/components/form/form-text.ts
+++ b/src/components/form/form-text.ts
@@ -1,7 +1,9 @@
 import { bindable, customElement } from 'aurelia-templating';
 import { bindingMode } from 'aurelia-binding';
+import { inject, TaskQueue } from 'aurelia-framework';
 
 @customElement('re-form-text')
+@inject(TaskQueue)
 export class ReFormText {
   @bindable({
     defaultBindingMode: bindingMode.oneTime
@@ -58,8 +60,17 @@ export class ReFormText {
     defaultBindingMode: bindingMode.oneWay
   }) validateOnKeyup: null | boolean = null;
 
+  @bindable({
+    defaulltBindingMode: bindingMode.oneTime
+  }) focusOnAttach: null | boolean = null;
+
+  private inputElement: null | HTMLInputElement = null;
   private _regex: RegExp = /./;
   private errorMessage: string = '';
+
+  constructor(
+    private taskQueue: TaskQueue
+  ) {}
 
   typeChanged(n: string) {
     this._resetRegex(n);
@@ -70,6 +81,13 @@ export class ReFormText {
   }
 
   attached() {
+    if (this.focusOnAttach) {
+      this.taskQueue.queueMicroTask(() => {
+        if (this.inputElement !== null) {
+          this.inputElement.focus();
+        }
+      });
+    }
     this._validate();
   }
 

--- a/src/components/form/form-textarea.ts
+++ b/src/components/form/form-textarea.ts
@@ -1,7 +1,9 @@
 import { bindable, customElement } from 'aurelia-templating';
 import { bindingMode } from 'aurelia-binding';
+import { TaskQueue, inject } from 'aurelia-framework';
 
 @customElement('re-form-textarea')
+@inject(TaskQueue)
 export class ReFormTextarea {
   @bindable({
     defaultBindingMode: bindingMode.oneTime
@@ -30,4 +32,24 @@ export class ReFormTextarea {
   }) value = '';
 
   @bindable() rows = '';
+
+  @bindable({
+    defaulltBindingMode: bindingMode.oneTime
+  }) focusOnAttach: null | boolean = null;
+
+  private inputElement: null | HTMLInputElement = null;
+
+  constructor(
+    private taskQueue: TaskQueue
+  ) {}
+
+  attached() {
+    if (this.focusOnAttach) {
+      this.taskQueue.queueMicroTask(() => {
+        if (this.inputElement !== null) {
+          this.inputElement.focus();
+        }
+      });
+    }
+  }
 }


### PR DESCRIPTION
Added ability to set focus to the input box when the element is attached to the DOM.

This should allow any forms or dialogs to set initial focus so we can have a better UX when we open up a new modal or load a page initially.

Helps to fix this issue:
https://redeyed.atlassian.net/browse/WFMDEV-2191